### PR TITLE
Add logic to pick default sensu version depending on Debian version.

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -13,7 +13,13 @@ class sensu::package {
     'Debian': {
       $pkg_title = 'sensu'
       $pkg_name = 'sensu'
-      $pkg_version = $sensu::version
+      # $pkg_version = $sensu::version
+
+      $pkg_version = $::lsbdistcodename ? {
+        'stretch' => '1.0.3-1',
+        'jessie'  => '1.0.2-1',
+      }
+
       $pkg_source = undef
 
       if $sensu::manage_repo {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -18,6 +18,7 @@ class sensu::package {
       $pkg_version = $::lsbdistcodename ? {
         'stretch' => '1.0.3-1',
         'jessie'  => '1.0.2-1',
+        default   => $sensu::version,
       }
 
       $pkg_source = undef


### PR DESCRIPTION
We currently are hardcoding $sensu::version in defaults.yaml in puppet-controlrepo. The version we have set is 1.0.2-1, which is not in the sensu apt repo for Debian stretch. 

I discovered this when I merged the latest version of production into my bind-git branches to get ready for some fresh server builds. This turned into an epic yak shave of an afternoon, and here we are. 

Any objections to moving the default version logic here into the module, rather than having it in defaults.yaml? We can't put a conditional in the yaml file. 